### PR TITLE
Normalize module exports with stdlib

### DIFF
--- a/src/backports/tempfile.py
+++ b/src/backports/tempfile.py
@@ -7,17 +7,18 @@ Backport modifications are marked with marked with "XXX backport".
 """
 from __future__ import absolute_import
 
-import sys
+import sys as _sys
 import warnings as _warnings
 from shutil import rmtree as _rmtree
 
-from backports.weakref import finalize
+from backports.weakref import finalize as _finalize
 
+from tempfile import *
 
 # XXX backport:  Rather than backporting all of mkdtemp(), we just create a
 # thin wrapper implementing its Python 3.5 signature.
-if sys.version_info < (3, 5):
-    from tempfile import mkdtemp as old_mkdtemp
+if _sys.version_info < (3, 5):
+    from tempfile import mkdtemp as _old_mkdtemp
 
     def mkdtemp(suffix=None, prefix=None, dir=None):
         """
@@ -26,50 +27,48 @@ if sys.version_info < (3, 5):
         kwargs = {k: v for (k, v) in
                   dict(suffix=suffix, prefix=prefix, dir=dir).items()
                   if v is not None}
-        return old_mkdtemp(**kwargs)
-
-else:
-    from tempfile import mkdtemp
+        return _old_mkdtemp(**kwargs)
 
 
 # XXX backport: ResourceWarning was added in Python 3.2.
 # For earlier versions, fall back to RuntimeWarning instead.
-_ResourceWarning = RuntimeWarning if sys.version_info < (3, 2) else ResourceWarning
+_ResourceWarning = RuntimeWarning if _sys.version_info < (3, 2) else ResourceWarning
 
 
-class TemporaryDirectory(object):
-    """Create and return a temporary directory.  This has the same
-    behavior as mkdtemp but can be used as a context manager.  For
-    example:
+if _sys.version_info < (3, 2):
+    class TemporaryDirectory(object):
+        """Create and return a temporary directory.  This has the same
+        behavior as mkdtemp but can be used as a context manager.  For
+        example:
 
-        with TemporaryDirectory() as tmpdir:
-            ...
+            with TemporaryDirectory() as tmpdir:
+                ...
 
-    Upon exiting the context, the directory and everything contained
-    in it are removed.
-    """
+        Upon exiting the context, the directory and everything contained
+        in it are removed.
+        """
 
-    def __init__(self, suffix=None, prefix=None, dir=None):
-        self.name = mkdtemp(suffix, prefix, dir)
-        self._finalizer = finalize(
-            self, self._cleanup, self.name,
-            warn_message="Implicitly cleaning up {!r}".format(self))
+        def __init__(self, suffix=None, prefix=None, dir=None):
+            self.name = mkdtemp(suffix, prefix, dir)
+            self._finalizer = _finalize(
+                self, self._cleanup, self.name,
+                warn_message="Implicitly cleaning up {!r}".format(self))
 
-    @classmethod
-    def _cleanup(cls, name, warn_message):
-        _rmtree(name)
-        _warnings.warn(warn_message, _ResourceWarning)
+        @classmethod
+        def _cleanup(cls, name, warn_message):
+            _rmtree(name)
+            _warnings.warn(warn_message, _ResourceWarning)
 
 
-    def __repr__(self):
-        return "<{} {!r}>".format(self.__class__.__name__, self.name)
+        def __repr__(self):
+            return "<{} {!r}>".format(self.__class__.__name__, self.name)
 
-    def __enter__(self):
-        return self.name
+        def __enter__(self):
+            return self.name
 
-    def __exit__(self, exc, value, tb):
-        self.cleanup()
+        def __exit__(self, exc, value, tb):
+            self.cleanup()
 
-    def cleanup(self):
-        if self._finalizer.detach():
-            _rmtree(self.name)
+        def cleanup(self):
+            if self._finalizer.detach():
+                _rmtree(self.name)

--- a/tests/test_tempfile.py
+++ b/tests/test_tempfile.py
@@ -46,11 +46,10 @@ class BaseTestCase(unittest.TestCase):
     def tearDown(self):
         self._warnings_manager.__exit__(None, None, None)
 
-
     def nameCheck(self, name, dir, pre, suf):  # pragma: no cover (test support code)
         (ndir, nbase) = os.path.split(name)
-        npre  = nbase[:len(pre)]
-        nsuf  = nbase[len(nbase)-len(suf):]
+        npre = nbase[:len(pre)]
+        nsuf = nbase[len(nbase)-len(suf):]
 
         # XXX backport: TODO: These do not test for unicode vs. str/bytes under Python < 3.
         # XXX backport: TODO: Enable unicode_literals and make these pass?
@@ -118,7 +117,7 @@ class TestTemporaryDirectory(BaseTestCase):
                             "TemporaryDirectory %s does not exist" % d.name)
             d.cleanup()
             self.assertFalse(os.path.exists(d.name),
-                        "TemporaryDirectory %s exists after cleanup" % d.name)
+                             "TemporaryDirectory %s exists after cleanup" % d.name)
         finally:
             os.rmdir(dir)
 
@@ -150,9 +149,9 @@ class TestTemporaryDirectory(BaseTestCase):
         try:
             d = self.do_create(dir=dir)
             name = d.name
-            del d # Rely on refcounting to invoke __del__
+            del d  # Rely on refcounting to invoke __del__
             self.assertFalse(os.path.exists(name),
-                        "TemporaryDirectory %s exists after __del__" % name)
+                             "TemporaryDirectory %s exists after __del__" % name)
         finally:
             os.rmdir(dir)
 
@@ -193,7 +192,7 @@ class TestTemporaryDirectory(BaseTestCase):
                 rc, out, err = script_helper.assert_python_ok("-c", code)
                 tmp_name = out.decode().strip()
                 self.assertFalse(os.path.exists(tmp_name),
-                            "TemporaryDirectory %s exists after cleanup" % tmp_name)
+                                 "TemporaryDirectory %s exists after cleanup" % tmp_name)
                 err = err.decode('utf-8', 'backslashreplace')
                 self.assertNotIn("Exception ", err)
                 # XXX backport:
@@ -221,7 +220,7 @@ class TestTemporaryDirectory(BaseTestCase):
             rc, out, err = script_helper.assert_python_ok("-c", code)
             tmp_name = out.decode().strip()
             self.assertFalse(os.path.exists(tmp_name),
-                        "TemporaryDirectory %s exists after cleanup" % tmp_name)
+                             "TemporaryDirectory %s exists after cleanup" % tmp_name)
             err = err.decode('utf-8', 'backslashreplace')
             self.assertNotIn("Exception ", err)
             # XXX backport:
@@ -239,7 +238,7 @@ class TestTemporaryDirectory(BaseTestCase):
                 del d
                 support.gc_collect()
             self.assertFalse(os.path.exists(name),
-                        "TemporaryDirectory %s exists after __del__" % name)
+                             "TemporaryDirectory %s exists after __del__" % name)
 
     def test_multiple_close(self):
         # Can be cleaned-up many times without error
@@ -255,3 +254,15 @@ class TestTemporaryDirectory(BaseTestCase):
             self.assertTrue(os.path.exists(name))
             self.assertEqual(name, d.name)
         self.assertFalse(os.path.exists(name))
+
+    def test_passthrough_imports(self):
+        from backports import tempfile as backports_tempfile
+        import tempfile
+
+        stdlib_exports = set([i for i in dir(tempfile) if not i.startswith("_")])
+        backports_exports = set([i for i in dir(backports_tempfile) if not i.startswith("_")])
+        for i in stdlib_exports:
+            if i != "template":
+                self.assertIn(i, backports_exports)
+        for i in backports_exports - stdlib_exports:
+            self.assertIn(i, {"TemporaryDirectory", "absolute_import"})


### PR DESCRIPTION
Pass through all tempfile exports. Hide implementation imports. Add
tests for this behavior.