### PR TITLE
Package the license file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
+[metadata]
+license_file = LICENSE
+
 [bdist_wheel]
 universal = 1


### PR DESCRIPTION
Make sure the license file is packaged in sdists, wheels, and other build products.